### PR TITLE
Add GitHub issue templates for bugs and features

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,27 @@
+name: Bug report
+description: Create a report to help us improve
+labels: bug
+body:
+  - type: textarea
+    attributes:
+      label: Describe the bug
+      description: Describe the bug.
+      placeholder: >
+        A clear and concise description of what the bug is.
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: To Reproduce
+      placeholder: >
+        Steps to reproduce the behavior:
+  - type: textarea
+    attributes:
+      label: Expected behavior
+      placeholder: >
+        A clear and concise description of what you expected to happen.
+  - type: textarea
+    attributes:
+      label: Additional context
+      placeholder: >
+        Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: true

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,26 @@
+name: Feature request
+description: Suggest an idea for this project
+labels: enhancement
+body:
+  - type: textarea
+    attributes:
+      label: Is your feature request related to a problem or challenge?
+      description: Please describe what you are trying to do.
+      placeholder: >
+        A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+        (This section helps developers understand the context and *why* for this feature, in addition to the *what*)
+  - type: textarea
+    attributes:
+      label: Describe the solution you'd like
+      placeholder: >
+        A clear and concise description of what you want to happen.
+  - type: textarea
+    attributes:
+      label: Describe alternatives you've considered
+      placeholder: >
+        A clear and concise description of any alternative solutions or features you've considered.
+  - type: textarea
+    attributes:
+      label: Additional context
+      placeholder: >
+        Add any other context or screenshots about the feature request here.


### PR DESCRIPTION
Introduces bug report and feature request templates to standardize issue submissions. Also enables blank issues via config.yml to improve project maintainability and user experience.
Fixes #30 
Hi @eccentriccoder01 , take a look