### PR TITLE
Improve textarea and select styling in proposal.css

### DIFF
--- a/styles/proposal.css
+++ b/styles/proposal.css
@@ -633,6 +633,11 @@ body {
     backdrop-filter: blur(10px);
 }
 
+.floating-label textarea {
+    min-height: 100px;
+    resize: vertical;
+}
+
 .floating-label input:focus,
 .floating-label textarea:focus,
 .floating-label input:not(:placeholder-shown),
@@ -754,6 +759,12 @@ body {
     backdrop-filter: blur(10px);
 }
 
+/* Fix option background in dark mode */
+.custom-select select option {
+    background: var(--bg-primary);
+    color: var(--text-primary);
+}
+
 .custom-select select:focus {
     border-color: var(--text-accent);
     box-shadow: 0 0 0 3px var(--focus-ring);
@@ -772,6 +783,7 @@ body {
     z-index: 2;
 }
 
+/* Arrow */
 .select-arrow {
     position: absolute;
     right: var(--space-lg);
@@ -782,9 +794,16 @@ body {
     transition: var(--transition-normal);
 }
 
+/* Arrow on focus */
 .custom-select select:focus ~ .select-arrow {
     color: var(--text-accent);
     transform: translateY(-50%) rotate(180deg);
+}
+
+.custom-select select:hover {
+    border-color: var(--text-accent);
+    color: var(--text-accent);
+    box-shadow: 0 0 12px rgba(75, 0, 130, 0.4);
 }
 
 /* Character Counter */


### PR DESCRIPTION
Fix issue #159
Closes https://github.com/eccentriccoder01/Venturalink/issues/159

> Added min-height and vertical resize for textareas in floating-label. Enhanced custom-select option backgrounds for dark mode and improved select hover/focus styles, including arrow behavior.

<img width="321" height="484" alt="image" src="https://github.com/user-attachments/assets/8a604313-1b49-4141-90fb-bf80fed1faf2" />

- Now the Select options are visible in any mode
- Fixed CSS

Please let me know if need any more changes...! 😇